### PR TITLE
chat-spaceフロント実装

### DIFF
--- a/app/assets/stylesheets/_message.scss
+++ b/app/assets/stylesheets/_message.scss
@@ -171,3 +171,5 @@ $textColor: #ffffff;
       }
     }  
   }
+
+  


### PR DESCRIPTION
#WHAT
chat-spaceのフロントの実装。

#WHY
フロントの実装を先に行うことにより、バックエンドの実装がわかりやすくなるため

![2020-01-13 17 53のイメージ](https://user-images.githubusercontent.com/59519639/72242864-bd904b80-362d-11ea-9a95-1e05c495a354.jpg)
